### PR TITLE
Update PyDL reference

### DIFF
--- a/src/refs.bib
+++ b/src/refs.bib
@@ -887,15 +887,15 @@ archivePrefix = "arXiv",
 
 @misc{pydl,
   author       = {Benjamin Alan Weaver and
-                  Thomas Robitaille and
-                  Erik Tollerud and
-                  José Sánchez-Gallego and
-                  Christoph Deil and
                   Kyle Barbary and
-                  Brigitta Sipocz and
                   Larry Bradley and
                   Matt Craig and
-                  Duncan Macleod},
+                  Christoph Deil and
+                  Duncan Macleod and
+                  Thomas Robitaille and
+                  José Sánchez-Gallego and
+                  Brigitta Sipocz and
+                  Erik Tollerud},
   title        = {weaverba137/pydl: Last Python 2 Release},
   month        = feb,
   year         = 2019,

--- a/src/refs.bib
+++ b/src/refs.bib
@@ -891,11 +891,14 @@ archivePrefix = "arXiv",
                   Larry Bradley and
                   Matt Craig and
                   Christoph Deil and
+                  Mike DiPompeo and
                   Duncan Macleod and
+                  Demitri Muna and
                   Thomas Robitaille and
                   José Sánchez-Gallego and
                   Brigitta Sipocz and
-                  Erik Tollerud},
+                  Erik Tollerud and
+                  Kyle Westfall},
   title        = {weaverba137/pydl: Last Python 2 Release},
   month        = feb,
   year         = 2019,

--- a/src/refs.bib
+++ b/src/refs.bib
@@ -886,23 +886,23 @@ archivePrefix = "arXiv",
 }
 
 @misc{pydl,
- author = {Benjamin Alan Weaver and
-           Kyle Barbary and
-           Larry Bradley and
-           Matt Craig and
-           Christoph Deil and
-           Mike DiPompeo and
-           Duncan Macleod and
-           Demitri Muna and
-           Thomas Robitaille and
-           Brigitta Sipocz and
-           Erik Tollerud and
-           Kyle Westfall},
-  title = {weaverba137/pydl: PyDL v0.6.0},
-  month = sep,
-   year = 2017,
-    doi = {10.5281/zenodo.1095151},
-    url = {https://doi.org/10.5281/zenodo.1095151}
+  author       = {Benjamin Alan Weaver and
+                  Thomas Robitaille and
+                  Erik Tollerud and
+                  José Sánchez-Gallego and
+                  Christoph Deil and
+                  Kyle Barbary and
+                  Brigitta Sipocz and
+                  Larry Bradley and
+                  Matt Craig and
+                  Duncan Macleod},
+  title        = {weaverba137/pydl: Last Python 2 Release},
+  month        = feb,
+  year         = 2019,
+  publisher    = {Zenodo},
+  version      = {0.7.0},
+  doi          = {10.5281/zenodo.2575874},
+  url          = {https://doi.org/10.5281/zenodo.2575874}
 }
 
 @INPROCEEDINGS{pythoncpl,
@@ -1718,6 +1718,3 @@ archivePrefix = {arXiv},
     url = {https://doi.org/10.1093/bioinformatics/btp163},
     eprint = {https://academic.oup.com/bioinformatics/article-pdf/25/11/1422/944180/btp163.pdf},
 }
-
-
-


### PR DESCRIPTION
This PR updates the PyDL reference to `v0.7.0`.  It is possible that a further version update may be needed before the paper is complete.  I'm hoping to get that done in early January 2022.