### PR TITLE
Contributor Role Taxonomy to specify what people did

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -252,7 +252,26 @@ Contributor to maintainer mentoring,
 Long-term / sustained funding for maintaining infrastructure,
 ...
 
+\section{Contributor Roles}
 
+Taken from \url{https://credit.niso.org/}
+Maybe in Alphabetical order
+\begin{itemize}
+    \item Conceptualization:
+    \item Data curation:
+    \item Formal Analysis:
+    \item Funding acquisition:
+    \item Investigation:
+    \item Methodology:
+    \item Project administration:
+    \item Resources:
+    \item Software: Wolfgang E. Kerzendorf (add ORCID), ADD yourself
+    \item Supervision
+    \item Validation
+    \item Visualization: Andrew Fullard
+    \item Writing - original draft
+    \item Writing - review & editing
+\end{itemize}
 \begin{acknowledgments}
 
 We would like to thank the members of the community that have contributed to


### PR DESCRIPTION
I like this contributor role section in my papers because there are so many ways to contribute to science and it gives a clearer picture of what everyone did. Maybe something for the Astropy paper. 