### PR TITLE
Affiliated packages draft text

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -377,15 +377,17 @@ Highlight a few new affiliated packages and major updates to existing ones.
 Include a big table of all affiliated packages and references (as in v2.0
 paper).
 
-All affiliated packages are listed on the astropy 
+All coordinated and affiliated packages are listed on the astropy
 website\footnote{\url{https://www.astropy.org/affiliated}}. Since 
-\cite{astropy:2018}, there has been an explosion of gravitational-wave affiliated 
-packages including: \texttt{PyCBC} for exploring GW sources, lenstronomy for 
-modeling strong gravitational lenses, \texttt{ligo.skymap} for visualizing GW 
-probability maps, and \texttt{EinsteinPy} for general relativity and gravitational astronomy. 
-There have been several packages related to HEALPix: \texttt{astropy-healpix}
+\cite{astropy:2018}, there has been an expansion of affiliated
+packages for gravitational astrophysics including:
+\texttt{PyCBC} for exploring gravitational wave signals, lenstronomy for
+modeling strong gravitational lenses, \texttt{ligo.skymap} for visualizing
+gravitational wave probability maps, and \texttt{EinsteinPy} for general
+relativity and gravitational astronomy. There have been several packages
+added to the ecosystem related to HEALPix: \texttt{astropy-healpix}
 for a BSD licensed HEALPix implementation, and \texttt{mocpy} for Multi-Order 
-Coverage maps. \texttt{astroalign} as been introduced for astrometric registration, 
+Coverage maps. \texttt{astroalign} has been introduced for astrometric registration,
 and \texttt{python-cpl} has been added for ESO pipelines and VLT data products. 
 For ground-based astronomy, \texttt{baseband} has added IO capabilities for 
 VLBI, and \texttt{SpectraPy} brings slit spectroscopy to the astropy ecosystem. 
@@ -398,8 +400,9 @@ pipelines. \texttt{BayesicFitting} provides an interface for generic Bayesian
 inference, and \texttt{sbpy} does calculations for asteroid and cometary 
 astrophysics. Finally, \texttt{synphot} provides an interface for synthetic photometry.
 
-Several of the affiliated packages described in [reference to paper 2] have
-had substantial improvements. \texttt{astroquery} \cite{astroquery} has added
+Several of the coordinated and affiliated packages described in [reference to
+paper 2] have had substantial improvements. \texttt{astroquery}
+\cite{astroquery} has added
 access to roughly a dozen new missions and data services, including JWST, and
 the project has switched to a continuous release model. Every time a change
 is committed to the main development branch it is published on the Python
@@ -416,6 +419,7 @@ feature is a function to align and co-add images to create a mosaic; better
 support for parallelization was also added. \texttt{specutils}, the package
 that defines containers for 1D and 2D spectra \cite{specutils}, also had its
 first stable release and the addition of classes to read JWST data.
+\texttt{stingray} has also had a major performance overhaul.
 
 \subsection{Connections with data archives}
 

--- a/src/ms.tex
+++ b/src/ms.tex
@@ -381,27 +381,26 @@ All coordinated and affiliated packages are listed on the astropy
 website\footnote{\url{https://www.astropy.org/affiliated}}. Since 
 \cite{astropy:2018}, there has been an expansion of affiliated
 packages for gravitational astrophysics including:
-\texttt{PyCBC} for exploring gravitational wave signals, lenstronomy for
+\texttt{PyCBC} for exploring gravitational wave signals, \texttt{lenstronomy} for
 modeling strong gravitational lenses, \texttt{ligo.skymap} for visualizing
 gravitational wave probability maps, and \texttt{EinsteinPy} for general
 relativity and gravitational astronomy. There have been several packages
 added to the ecosystem related to HEALPix: \texttt{astropy-healpix}
-for a BSD licensed HEALPix implementation, and \texttt{mocpy} for Multi-Order 
+for a BSD-licensed HEALPix implementation, and \texttt{mocpy} for Multi-Order
 Coverage maps. \texttt{astroalign} has been introduced for astrometric registration,
 and \texttt{python-cpl} has been added for ESO pipelines and VLT data products. 
 For ground-based astronomy, \texttt{baseband} has added IO capabilities for 
 VLBI, and \texttt{SpectraPy} brings slit spectroscopy to the astropy ecosystem. 
-We have \texttt{agnpy} for AGN astrophysics, and \texttt{statmorph} for fitting galactic 
+We have \texttt{agnpy} for AGN jets, and \texttt{statmorph} for fitting galactic
 morphological diagnostics. \texttt{saba} gives an interface to sherpa's fitting 
 routines. For modeling interstellar dust extinction we have 
 \texttt{dust_extinction}, and for extracting features from time series we 
 have \texttt{feets}. We also have \texttt{corral} for managing data intensive parallel 
 pipelines. \texttt{BayesicFitting} provides an interface for generic Bayesian 
-inference, and \texttt{sbpy} does calculations for asteroid and cometary 
+inference, and \texttt{sbpy} \cite{Mommert2019} does calculations for asteroid and cometary
 astrophysics. Finally, \texttt{synphot} provides an interface for synthetic photometry.
 
-Several of the coordinated and affiliated packages described in [reference to
-paper 2] have had substantial improvements. \texttt{astroquery}
+Several of the coordinated and affiliated packages described in \cite{astropy:2018} have had substantial improvements. \texttt{astroquery}
 \cite{astroquery} has added
 access to roughly a dozen new missions and data services, including JWST, and
 the project has switched to a continuous release model. Every time a change

--- a/src/ms.tex
+++ b/src/ms.tex
@@ -419,7 +419,9 @@ feature is a function to align and co-add images to create a mosaic; better
 support for parallelization was also added. \texttt{specutils}, the package
 that defines containers for 1D and 2D spectra \cite{specutils}, also had its
 first stable release and the addition of classes to read JWST data.
-\texttt{stingray} has also had a major performance overhaul.
+\texttt{stingray} has also had a major performance overhaul. The package
+\texttt{gammapy} \cite{gammapy} also has major performance improvements,
+has unified its API in preparation for its first stable release.
 
 \subsection{Connections with data archives}
 

--- a/src/ms.tex
+++ b/src/ms.tex
@@ -394,7 +394,7 @@ VLBI, and \texttt{SpectraPy} brings slit spectroscopy to the astropy ecosystem.
 We have \texttt{agnpy} for AGN jets, and \texttt{statmorph} for fitting galactic
 morphological diagnostics. \texttt{saba} gives an interface to sherpa's fitting 
 routines. For modeling interstellar dust extinction we have 
-\texttt{dust_extinction}, and for extracting features from time series we 
+\texttt{dust\_extinction}, and for extracting features from time series we
 have \texttt{feets}. We also have \texttt{corral} for managing data intensive parallel 
 pipelines. \texttt{BayesicFitting} provides an interface for generic Bayesian 
 inference, and \texttt{sbpy} \cite{Mommert2019} does calculations for asteroid and cometary

--- a/src/ms.tex
+++ b/src/ms.tex
@@ -377,6 +377,46 @@ Highlight a few new affiliated packages and major updates to existing ones.
 Include a big table of all affiliated packages and references (as in v2.0
 paper).
 
+All affiliated packages are listed on the astropy 
+website\footnote{\url{https://www.astropy.org/affiliated}}. Since 
+\cite{astropy:2018}, there has been an explosion of gravitational-wave affiliated 
+packages including: \texttt{PyCBC} for exploring GW sources, lenstronomy for 
+modeling strong gravitational lenses, \texttt{ligo.skymap} for visualizing GW 
+probability maps, and \texttt{EinsteinPy} for general relativity and gravitational astronomy. 
+There have been several packages related to HEALPix: \texttt{astropy-healpix}
+for a BSD licensed HEALPix implementation, and \texttt{mocpy} for Multi-Order 
+Coverage maps. \texttt{astroalign} as been introduced for astrometric registration, 
+and \texttt{python-cpl} has been added for ESO pipelines and VLT data products. 
+For ground-based astronomy, \texttt{baseband} has added IO capabilities for 
+VLBI, and \texttt{SpectraPy} brings slit spectroscopy to the astropy ecosystem. 
+We have \texttt{agnpy} for AGN astrophysics, and \texttt{statmorph} for fitting galactic 
+morphological diagnostics. \texttt{saba} gives an interface to sherpa's fitting 
+routines. For modeling interstellar dust extinction we have 
+\texttt{dust_extinction}, and for extracting features from time series we 
+have \texttt{feets}. We also have \texttt{corral} for managing data intensive parallel 
+pipelines. \texttt{BayesicFitting} provides an interface for generic Bayesian 
+inference, and \texttt{sbpy} does calculations for asteroid and cometary 
+astrophysics. Finally, \texttt{synphot} provides an interface for synthetic photometry.
+
+Several of the affiliated packages described in [reference to paper 2] have
+had substantial improvements. \texttt{astroquery} \cite{astroquery} has added
+access to roughly a dozen new missions and data services, including JWST, and
+the project has switched to a continuous release model. Every time a change
+is committed to the main development branch it is published on the Python
+Package Index (PyPI, ref) and available for installation. Formal releases are
+still done a couple of times per year. \texttt{photutils} \cite
+{photutils} released its first stable version, indicating that the API will
+change less frequently, and there have been several significant performance
+improvements.  \texttt{ccdproc} \cite{ccdproc} also released a new major
+version, bringing better performance to some image combination operations.
+The \texttt{regions} package \cite{pyregions}, for manipulating ds9-style
+region definitions \cite{ds9}, added new ways to manipulate regions and
+introduced new region types. \texttt{reproject}’s \cite{reproject} major new
+feature is a function to align and co-add images to create a mosaic; better
+support for parallelization was also added. \texttt{specutils}, the package
+that defines containers for 1D and 2D spectra \cite{specutils}, also had its
+first stable release and the addition of classes to read JWST data.
+
 \subsection{Connections with data archives}
 
 \secauthor{Adam Ginsburg}

--- a/src/refs.bib
+++ b/src/refs.bib
@@ -1843,4 +1843,16 @@ archivePrefix = {ascl},
           doi = {10.1016/j.ascom.2015.06.004},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2015A&C....12..240G},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+
+@article{Mommert2019,
+  doi = {10.21105/joss.01426},
+  url = {https://doi.org/10.21105/joss.01426},
+  year = {2019},
+  publisher = {The Open Journal},
+  volume = {4},
+  number = {38},
+  pages = {1426},
+  author = {Michael Mommert and Michael S. p. Kelley and Miguel de Val-Borro and Jian-Yang Li and Giannina Guzman and Brigitta Sipőcz and Josef Ďurech and Mikael Granvik and Will Grundy and Nick Moskovitz and Antti Penttilä and Nalin Samarasinha},
+  title = {sbpy: A Python module for small-body planetary astronomy},
+  journal = {Journal of Open Source Software}
 }


### PR DESCRIPTION
Committed in collaboration with @mwcraig. Supersedes #19.

Also, a note for posterity: 

The latest affiliated registry at time of writing is [here](https://raw.githubusercontent.com/astropy/astropy.github.com/f4a9299b2e8c5cc6b5bc9e4f5b435fb876f02ea3/affiliated/registry.json), and the commit of affiliated registry at the time of publication of Astropy paper II is [here](https://raw.githubusercontent.com/astropy/astropy.github.com/de6158e73d58be389783109245086f2e26ba24e9/affiliated/registry.json). A `diff` of these two files was used to construct the list of new affiliates since 2018.