### PR TITLE
Add a missing comma and space

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -274,7 +274,7 @@ bad data values with a flag or by replacing them with a special
 value, e.g., ``Not a Number'' (NaN). In \astropypkg, both approaches are
 used: a flag for masked columns in \astropyTable, mask flags and bitmaps
 for N-dimensional data in \astropysubpkg{nddata}, and replacing elements with
-NaN in \astropyTime. However masked \astropyQuantity support is currently very limited,
+NaN in \astropyTime. However, masked \astropyQuantity\ support is currently very limited,
 hindering usage of masks in a \astropyQTable\ (in which \astropyQuantity\ is used
 for all columns with units).
 

--- a/src/ms.tex
+++ b/src/ms.tex
@@ -373,7 +373,7 @@ Units were also integrated further within \astropypkg. For an already-defined
 unit-less \astropyModel, e.g., those imported from another library,
 \astropymodeling can now coerce units. A new module – \astropycosmologyunits –
 has been added to the cosmology sub-package for defining and collecting
-cosmological units and equivalencies. \astropycosmologyunits has a unit and
+cosmological units and equivalencies. \astropycosmologyunits\ has a unit and
 equivalencies for \texttt{littleh}, and a new unit, \texttt{redshift}, for
 factors of cosmological redshift. \texttt{redshift} has a number of
 equivalencies for converting between cosmological distance measures, e.g., CMB


### PR DESCRIPTION
- Comma after "However": generally good style, and seems to be used
  everywhere else "however" is used.
- Escape a space after a \command.
