### PR TITLE
Use citep when describing affiliated packages

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -1048,19 +1048,19 @@ services, including the James Webb Space Telescope (JWST) archive, and the
 project has switched to a continuous release model: every time a change is
 committed to the main development branch it is published on the Python Package
 Index (PyPI) and available for installation. (However, formal releases are still
-done a few times per year.) \texttt{photutils} \cite{photutils} released its
+done a few times per year.) \texttt{photutils} \citep{photutils} released its
 first stable version, indicating that the API will change less frequently, and
 there have been several significant performance improvements. \texttt{ccdproc}
-\cite{ccdproc} also released a new major version, bringing better performance to
+\citep{ccdproc} also released a new major version, bringing better performance to
 some image combination operations. The \texttt{regions} package
-\cite{pyregions}, for manipulating ds9-style region definitions \cite{ds9},
+\citep{pyregions}, for manipulating ds9-style region definitions \citep{ds9},
 added new ways to manipulate regions and introduced new region types.
-\texttt{reproject}'s \cite{reproject} major new feature is a function to align
+\texttt{reproject}'s \citep{reproject} major new feature is a function to align
 and co-add images to create a mosaic; better support for parallelization was
 also added. \texttt{specutils}, the package that defines containers for 1D and
-2D spectra \cite{specutils}, also had its first stable release and the addition
+2D spectra \citep{specutils}, also had its first stable release and the addition
 of classes to read JWST data. \texttt{stingray} has also had a major performance
-overhaul. The package \texttt{gammapy} \cite{gammapy} also has major performance
+overhaul. The package \texttt{gammapy} \citep{gammapy} also has major performance
 improvements and has unified its API in preparation for its first stable
 release.
 


### PR DESCRIPTION
A lot of places in 4.2 used \cite when \citep would be more appropriate.
