### PR TITLE
Use "open-source" everywhere, not "open source"

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -807,13 +807,13 @@ this process are described below.
 coders from traditionally marginalized groups, most notably women of
 color. Participants were invited to the WoCCode Slack space and
 encouraged to attend monthly webinars to share skills in the context
-of open source software libraries. Every other month, a guest speaker
+of open-source software libraries. Every other month, a guest speaker
 was invited to talk about their career path and share a skill. Program
 participants were solicited in the fall of 2020, yielding 73
 applications from 17 countries (48\% from the United States, 37\% from
 Africa, and 15\% from remaining continents). We selected participants
-who we identified as having a high potential for contributing to open
-source projects: intermediate to advanced programming skills with a
+who we identified as having a high potential for contributing to
+open-source projects: intermediate to advanced programming skills with a
 vocal interest in contributing. Of the thirty applicants invited to
 the program, nineteen joined the community on Slack. Participants were
 organized into cohorts based on interest and each cohort was assigned
@@ -851,7 +851,7 @@ and understanding the Git and \github workflow is not part of the standard
 Physics and Astrophysics curriculum. Additionally, the larger astronomical
 community is still in the process of transitioning towards \python-based tools,
 making it difficult for students not currently under advisement by some one with
-extensive \python expertise to get involved with the open source \python
+extensive \python expertise to get involved with the open-source \python
 community. Projects such as Learn Astropy (see Section~\ref{sec:learn}) could
 have a profound impact by empowering underrepresented groups because it provides
 a free, searchable, and accessible introduction to \python tools for
@@ -859,7 +859,7 @@ astrophysical research. Representatives also noted that offering training and
 teaching materials to PIs of Research Experience for Undergraduate (REU)
 programs throughout the United States could be helpful for encouraging advisors
 to teach students how to use Astropy, create their own libraries, and use
-version control on open source platforms like \github. Such materials could also
+version control on open-source platforms like \github. Such materials could also
 be offered as a workshop at national diversity conferences themselves, as SACNAS
 solicits special session proposals each year.
 
@@ -880,7 +880,7 @@ Section~\ref{sec:project-governance}), established a standing Finance Committee.
 This committee oversees the planning and allocation of finances on behalf
 of the Project. The Astropy Project accepts funds from institutions as well as
 individuals through NumFOCUS.\footnote{NumFOCUS is a 501(c)(3) nonprofit that
-supports and promotes world-class, innovative, open source scientific computing.}
+supports and promotes world-class, innovative, open-source scientific computing.}
 Previously, no direct financial support was available for the project development,
 and NumFOCUS covered most of the incurred operational costs. However, transitioning
 to long-term financial stability meant having an influx of funds in the form of
@@ -1175,7 +1175,7 @@ CTA will be able to observe gamma rays in a broad energy range from around $20\,
 using three different types of telescopes. In total over 100 telescopes are planned at the two sites.
 CTA will also be the first open gamma-ray observatory.
 
-The data analysis pipeline is developed as open source software and essentially split in two domains:
+The data analysis pipeline is developed as open-source software and essentially split in two domains:
 \begin{enumerate}
   \item In the low-level analysis, the properties of the recorded air-shower events
     have to be estimated from the raw data.
@@ -1325,7 +1325,7 @@ Funding for the exhibit hall was provided alternately by NumFOCUS and later by
 the Moore Foundation funding.
 The booth hosted a series of Q\&A special sessions during AAS 235 and webinars
 during the virtual AAS 237 meetings, to provide the general astronomy community
-information and access to experts on a variety of open source astronomical
+information and access to experts on a variety of open-source astronomical
 tools.
 
 % \subsubsection{Learn vision for the future}
@@ -1405,7 +1405,7 @@ adopted via pull request in December 2021.
 
 Over the history of \astropy, the needs and challenges of the \astropy Project
 have evolved, but many common themes have persisted and are shared by other
-open source software communities.
+open-source software communities.
 However, \astropy also faces a number of unique challenges stemming from the
 fact that the Project is in a special position in the astronomy software stack:
 The \astropy code and ecosystem are more specialized than core scientific tools


### PR DESCRIPTION
Previously the text contained both "open-source" and "open source". The instances of "open source" have now been replaced with "open-source" for the sake of consistency, except the one instance that is commented out.