### PR TITLE
Use "APE 0" everywhere instead of "APE0"

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -618,24 +618,24 @@ implemented by the ``Astropy Governance Implementation Working Group'' in Fall
 changing circumstances, it is expected that this is the framework Astropy's
 governance will operate in for at least the medium-term future.
 
-The APE0 \citep{ape0} document lays out the principles of this governance
+The APE 0 \citep{ape0} document lays out the principles of this governance
 structure, so we refer the reader to that document for a more thorough
 description, and here we only highlight some key elements. While many of these
 principles were already de facto true or have been discussed organically (and
-have been discussed in earlier papers in this series), the APE0-based governance
+have been discussed in earlier papers in this series), the APE 0-based governance
 aims to provide a single place where the community can agree as a starting
 point. With this in mind, it highlights the developer and user community of the
 Astropy Project as the ultimate sources of authority, as well as the core
 principle of ``do-ocracy'': those who do work for the Project (be it coding,
 training, or other harder-to-quantify contributions) gain more influence on the
-outputs of the Project by virtue of their effort. However, APE0 adds the
+outputs of the Project by virtue of their effort. However, APE 0 adds the
 concept of ``voting members'': a self-governed part of that community who are
 entrusted to elect the Coordination Committee (CoCo). While the CoCo has existed
-from the inception of the project, APE0 establishes a formal voting process for
+from the inception of the project, APE 0 establishes a formal voting process for
 CoCo members, and explicitly outlines the rights and responsibilities of the
 CoCo. This role is mainly to facilitate consensus and act as the decision maker
 when other mechanisms have failed, and includes powers that either
-require central authority or secrets (e.g., passwords). However, APE0 also
+require central authority or secrets (e.g., passwords). However, APE 0 also
 charges the Committee to devolve responsibilities and seek community input on
 these items as often as possible.
 


### PR DESCRIPTION
This is to be consistent with other mentions of enhancement proposals (e.g. APE 14, NEP 18, PEP 8).