### PR TITLE
Unify affiliations for SARAO

### DIFF
--- a/src/static/authors.tex
+++ b/src/static/authors.tex
@@ -29,6 +29,10 @@
     Steward Observatory, University of Arizona, 933 North Cherry Avenue, Tucson,
     AZ 85721-0065, USA
 }
+\newcommand{\affsarao}{
+    South African Radio Astronomy Observatory, 2 Fir Street, Black River Park,
+    Observatory 7925, South Africa
+}
 
 
 % Paper coordinators, ordered by contributions:
@@ -97,7 +101,7 @@
 \affiliation{\affaperio}
 
 \author{Bruce~Merry}
-\affiliation{South African Radio Astronomy Observatory, 2 Fir Street, Black River Park, Observatory 7925, South Africa}
+\affiliation{\affsarao}
 
 \author{Matteo~Bachetti}
 \affiliation{Istituto Nazionale di Astrofisica/Osservatorio Astronomico di Cagliari, via della Scienza 5, I-09047 Selargius (CA), Italy}
@@ -375,7 +379,7 @@ Argentina}
 \affiliation{EPFL SCITAS, Station 9, CH-1015 Lausanne, Switzerland}
 
 \author{Ludwig~Schwardt}
-\affiliation{South African Radio Astronomy Observatory, Black River Park, 2 Fir Street, Observatory 7925, South Africa}
+\affiliation{\affsarao}
 
 \author{Michael~Seifert-Eckert}
 \noaffiliation


### PR DESCRIPTION
They were written with the address line in different order. I've used
the version that matches https://www.sarao.ac.za/contact/
