### PR TITLE
Fix reference to regions package in main text

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -1073,7 +1073,7 @@ first stable version, indicating that the API will change less frequently, and
 there have been several significant performance improvements. \texttt{ccdproc}
 \citep{ccdproc}  released a new major version, bringing better performance to
 some image combination operations. The \texttt{regions} package
-\citep{pyregions}, for manipulating ds9-, CASA-, or FITS-style region definitions \citep{ds9},
+\citep{regions}, for manipulating ds9-, CASA-, or FITS-style region definitions \citep{ds9},
 added new ways to manipulate regions, introduced new region types, and obtained
 expanded visualization and interactive region editing capabilities.
 \texttt{reproject}'s \citep{reproject} major new feature is a function to align

--- a/src/static/affiliated-refs.bib
+++ b/src/static/affiliated-refs.bib
@@ -959,3 +959,41 @@ abstract = {We present an algorithm implemented in the Astroalign Python module 
   doi          = {10.5281/zenodo.6354163},
   url          = {https://doi.org/10.5281/zenodo.6354163}
 }
+
+@software{specutils,
+  author       = {Nicholas Earl and
+                  Erik Tollerud and
+                  Craig Jones and
+                  Wolfgang Kerzendorf and
+                  Ricky O'Steen and
+                  Ivo Busko and
+                  shaileshahuja and
+                  Dan D'Avella and
+                  Thomas Robitaille and
+                  Adam Ginsburg and
+                  Derek Homeier and
+                  Brigitta Sipőcz and
+                  Jesse Averbukh and
+                  James Tocknell and
+                  Brian Cherinka and
+                  Sara Ogaz and
+                  Robel Geda and
+                  James Davies and
+                  Hans Moritz Günther and
+                  Kyle Barbary and
+                  P. L. Lim and
+                  Jonathan Foster and
+                  Kyle Conroy and Michael Droettboom and Simon Torres and
+                  E. M. Bray and
+                  Andy Casey and
+                  Peter Teuben and
+                  Steve Crawford and
+                  Henry Ferguson},
+  title        = {astropy/specutils: V1.5.0},
+  month        = nov,
+  year         = 2021,
+  publisher    = {Zenodo},
+  version      = {v1.5.0},
+  doi          = {10.5281/zenodo.5721652},
+  url          = {https://doi.org/10.5281/zenodo.5721652}
+}

--- a/src/static/affiliated-refs.bib
+++ b/src/static/affiliated-refs.bib
@@ -110,14 +110,14 @@ archivePrefix = {arXiv},
 
 @ARTICLE{astroquery,
    author = {{Ginsburg}, A. and {Sip{\H o}cz}, B.~M. and {Brasseur}, C.~E. and
-	{Cowperthwaite}, P.~S. and {Craig}, M.~W. and {Deil}, C. and
-	{Guillochon}, J. and {Guzman}, G. and {Liedtke}, S. and {Lian Lim}, P. and
-	{Lockhart}, K.~E. and {Mommert}, M. and {Morris}, B.~M. and
-	{Norman}, H. and {Parikh}, M. and {Persson}, M.~V. and {Robitaille}, T.~P. and
-	{Segovia}, J.-C. and {Singer}, L.~P. and {Tollerud}, E.~J. and
-	{de Val-Borro}, M. and {Valtchanov}, I. and {Woillez}, J. and
-	{The Astroquery collaboration} and {a subset of the astropy collaboration}
-	},
+    {Cowperthwaite}, P.~S. and {Craig}, M.~W. and {Deil}, C. and
+    {Guillochon}, J. and {Guzman}, G. and {Liedtke}, S. and {Lian Lim}, P. and
+    {Lockhart}, K.~E. and {Mommert}, M. and {Morris}, B.~M. and
+    {Norman}, H. and {Parikh}, M. and {Persson}, M.~V. and {Robitaille}, T.~P. and
+    {Segovia}, J.-C. and {Singer}, L.~P. and {Tollerud}, E.~J. and
+    {de Val-Borro}, M. and {Valtchanov}, I. and {Woillez}, J. and
+    {The Astroquery collaboration} and {a subset of the astropy collaboration}
+    },
     title = "{astroquery: An Astronomical Web-querying Package in Python}",
   journal = {\aj},
 archivePrefix = "arXiv",
@@ -147,12 +147,12 @@ archivePrefix = "arXiv",
                   Axel Donath and
                   Hans Moritz Günther and
                   Mihai Cara and
-                  krachyon and
+                  P. L. Lim and
+                  Sebastian Meßlinger and
                   Simon Conseil and
                   Azalee Bostroem and
                   Michael Droettboom and
                   E. M. Bray and
-                  P. L. Lim and
                   Lars Andersen Bratholm and
                   Geert Barentsen and
                   Matt Craig and
@@ -165,13 +165,13 @@ archivePrefix = "arXiv",
                   Yoonsoo P. Bach and
                   Bruno Quint and
                   Harrison Souchereau},
-  title        = {astropy/photutils: 1.3.0},
-  month        = dec,
-  year         = 2021,
+  title        = {astropy/photutils: 1.4.0},
+  month        = mar,
+  year         = 2022,
   publisher    = {Zenodo},
-  version      = {1.3.0},
-  doi          = {10.5281/zenodo.5796924},
-  url          = {https://doi.org/10.5281/zenodo.5796924}
+  version      = {1.4.0},
+  doi          = {10.5281/zenodo.6385735},
+  url          = {https://doi.org/10.5281/zenodo.6385735}
 }
 
 @inproceedings{ginga,
@@ -782,23 +782,24 @@ archivePrefix = {arXiv},
                   Brigitta Sipőcz and
                   Johannes King and
                   P. L. Lim and
+                  Derek Homeier and
                   Leo Singer and
                   Miguel de Val-Borro and
                   Tim Jenness and
                   Matthieu Baumann and
-                  Yash-10 and
+                  Yash Gondhalekar and
                   Axel Donath and
                   Erik Tollerud and
                   Jae-Joon Lee and
                   Katrin Leinweber and
                   Zé Vinícius},
-  title        = {astropy/regions: v0.5},
-  month        = jan,
+  title        = {astropy/regions: v0.6},
+  month        = mar,
   year         = 2022,
   publisher    = {Zenodo},
-  version      = {v0.5},
-  doi          = {10.5281/zenodo.5826359},
-  url          = {https://doi.org/10.5281/zenodo.5826359}
+  version      = {v0.6},
+  doi          = {10.5281/zenodo.6374572},
+  url          = {https://doi.org/10.5281/zenodo.6374572}
 }
 
 @MISC{synphot,


### PR DESCRIPTION
This PR also updates the `photutils` and `regions` references and adds a `specutils` reference in the `affiliated-refs.bib` file, which is used to autogenerate the affiliated package table.