### PR TITLE
Add affiliated package  references in text

### DIFF
--- a/src/ms.tex
+++ b/src/ms.tex
@@ -1038,26 +1038,26 @@ in the Appendix below (Table~\ref{tab:affiliated-registry}).
 
 Since \paperii, there has been an expansion of affiliated
 packages for gravitational astrophysics, including:
-\texttt{PyCBC} for exploring gravitational wave signals, \texttt{lenstronomy} for
+\texttt{PyCBC} \cite{PyCBC} for exploring gravitational wave signals, \texttt{lenstronomy} \cite{lenstronomy:1} for
 modeling strong gravitational lenses, \texttt{ligo.skymap} for visualizing
-gravitational wave probability maps, and \texttt{EinsteinPy} for general
+gravitational wave probability maps, and \texttt{EinsteinPy} \cite{EinsteinPy} for general
 relativity and gravitational astronomy. There have also been several packages
 added to the ecosystem related to HEALPix: \texttt{astropy-healpix}
 for a BSD-licensed HEALPix implementation, and \texttt{mocpy} for Multi-Order
-Coverage maps. \texttt{astroalign} has been introduced for astrometric registration,
-and \texttt{python-cpl} has been added for ESO pipelines and VLT data products.
-For ground-based astronomy, \texttt{baseband} has added IO capabilities for
-VLBI, and \texttt{SpectraPy} brings slit spectroscopy to the \astropy ecosystem.
-Other new affiliated packages include \texttt{agnpy} for AGN jets,
-\texttt{statmorph} for fitting galactic morphological diagnostics,
+Coverage maps. \texttt{astroalign}  \cite{astroalign} has been introduced for astrometric registration,
+and \texttt{python-cpl} products \cite{pythoncpl} has been added for ESO pipelines and VLT data.
+For ground-based astronomy, \texttt{baseband} \cite{baseband} has added IO capabilities for
+VLBI, and \texttt{SpectraPy} \cite{SpectraPy} brings slit spectroscopy to the \astropy ecosystem.
+Other new affiliated packages include \texttt{agnpy} \cite{agnpy} for AGN jets,
+\texttt{statmorph}  \cite{statmorph}for fitting galactic morphological diagnostics,
 \texttt{dust\_extinction} for modeling interstellar dust extinction,
 \texttt{feets} for extracting features from time series data, and
-\texttt{corral} for managing data intensive parallel pipelines.
+\texttt{corral} \cite{corral} for managing data intensive parallel pipelines.
 \texttt{casaformats-io} provides infrastructure for reading data stored in CASA table formats.
 \texttt{saba} gives an interface to the Sherpa \citep{sherpa} fitting routines,
-\texttt{BayesicFitting} provides an interface for generic Bayesian inference,
-and \texttt{sbpy} enables calculations for asteroid and
-cometary astrophysics. Finally, \texttt{synphot} provides an interface for
+\texttt{BayesicFitting} \cite{BayesicFitting} provides an interface for generic Bayesian inference,
+and \texttt{sbpy} \cite{sbpy} enables calculations for asteroid and
+cometary astrophysics. Finally, \texttt{synphot} \cite{synphot} provides an interface for
 synthetic photometry.
 % \citep{Mommert2019}
 

--- a/src/ms.tex
+++ b/src/ms.tex
@@ -1080,7 +1080,7 @@ expanded visualization and interactive region editing capabilities.
 and co-add images to create a mosaic; better support for parallelization was
 also added. \texttt{specutils}, the package that defines containers for 1D and
 2D spectra \citep{specutils},  had its first stable release and the addition
-of classes to read JWST data. \texttt{stingray} has had a major performance
+of classes to read JWST data. \texttt{stingray} \citep{stingray:2} has had a major performance
 overhaul. The package \texttt{gammapy} \citep{gammapy} has had major performance
 improvements and has unified its API in preparation for its first stable
 release.


### PR DESCRIPTION
This adds references in the text to the affiliated packages that are mentioned in the text that have an unambiguous way to cite them.